### PR TITLE
Fixes and enhancements

### DIFF
--- a/nsdf/nsdfwriter.py
+++ b/nsdf/nsdfwriter.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Fri Apr 25 19:51:42 2014 (+0530)
 # Version: 
-# Last-Updated: Sun Jan 17 14:16:49 2016 (-0500)
-#           By: subha
-#     Update #: 13
+# Last-Updated: Fri Feb  2 15:41:16 2018 (-0500)
+#           By: Subhasis Ray
+#     Update #: 17
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -495,7 +495,11 @@ class NSDFWriter(object):
             
         if len(id_path_dict) > 1:
             # there are elements other than /model/modeltree
-            paths = [id_path_dict[uid] for uid in idlist]
+            try:
+                paths = [id_path_dict[uid] for uid in idlist]
+            except KeyError:
+                print('Warning: modeltree does not include source ids in the DS')
+                return
             prefix = common_prefix(paths)[len('/modeltree/'):]
             try:
                 source = self.modeltree[prefix]
@@ -572,7 +576,7 @@ class NSDFWriter(object):
                     fhandle.readinto(buf)
                 components = []
                 while True:
-                    head, tail = os.path.split(fame)
+                    head, tail = os.path.split(fname)
                     if tail:
                         components.append(tail)
                     if not head:
@@ -1443,7 +1447,7 @@ class NSDFWriter(object):
                 a dimension scale called `source` on the row
                 dimension.
 
-            data_object (nsdf.EventData): NSDFData object storing
+            data_object (nsdf.StaticData): NSDFData object storing
                 the data for all sources in `source_ds`.
             
             fixed (bool): if True, the data cannot grow. Default: True

--- a/nsdf/nsdfwriter.py
+++ b/nsdf/nsdfwriter.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Fri Apr 25 19:51:42 2014 (+0530)
 # Version: 
-# Last-Updated: Fri Feb  2 20:28:08 2018 (-0500)
+# Last-Updated: Tue Feb  6 13:58:38 2018 (-0500)
 #           By: Subhasis Ray
-#     Update #: 97
+#     Update #: 98
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -320,6 +320,8 @@ class NSDFWriter(object):
             creator_list (list of str): list of creators of the file.
 
         """
+        if isinstance(creator_list, basestring):
+            creator_list = [creator_list]
         attr = np.zeros((len(creator_list),), dtype=VLENSTR)
         attr[:] = creator_list
         self._fd.attrs['creator'] = attr                
@@ -350,6 +352,8 @@ class NSDFWriter(object):
                 involved in generating the data in the file.
 
         """
+        if isinstance(software_list, basestring):
+            software_list = [software_list]        
         attr = np.zeros((len(software_list),), dtype=VLENSTR)
         attr[:] = software_list
         self._fd.attrs['software'] = attr
@@ -368,6 +372,8 @@ class NSDFWriter(object):
                 to generate the data.
 
         """
+        if isinstance(method_list, basestring):
+            method_list = [method_list]
         attr = np.zeros((len(method_list),), dtype=VLENSTR)
         attr[:] = method_list
         self._fd.attrs['method'] = attr                
@@ -461,6 +467,8 @@ class NSDFWriter(object):
                 contributed towards the data stored in the file.
 
         """
+        if isinstance(contributor_list, basestring):
+            contributor_list = [contributor_list]
         attr = np.zeros((len(contributor_list),), dtype=VLENSTR)
         attr[:] = contributor_list
         self._fd.attrs['contributor'] = attr                

--- a/nsdf/util.py
+++ b/nsdf/util.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Mon Jul 28 15:13:33 2014 (+0530)
 # Version: 
-# Last-Updated: 
-#           By: 
-#     Update #: 0
+# Last-Updated: Fri Feb  2 17:14:41 2018 (-0500)
+#           By: Subhasis Ray
+#     Update #: 9
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -59,6 +59,7 @@ __author__ = 'Subhasis Ray'
 import numpy as np
 from itertools import chain
 import h5py as h5
+import os
 
 def node_finder(container_list, match_fn):
     """Return a function that can be passed to h5py.Group.visititem to
@@ -196,6 +197,20 @@ def printtree(root, vchar='|', hchar='__', vcount=1, depth=0, prefix='', is_last
     if len(children) > 0:
         printtree(root[children[-1]], vchar, hchar, vcount, depth + 1, prefix, True)
         
-
+def split_os_path(path):
+    """Inverse of os.path.join()"""
+    components = []
+    while True:
+        path, tail = os.path.split(path)
+        if tail:
+            components.append(tail)
+        else:
+            if path:
+                components.append(path)
+            break
+    components.reverse()
+    return components
+    
+        
 # 
 # util.py ends here


### PR DESCRIPTION
1. When saving file contents in model as HDF5 nodes, sanitize the file paths by removing '..' or '.'. Now user must specify a base directory. The node tree under /model/filecontents is created with paths relative to this base directory.
2. When data sources are not available in model tree raise warning instead of exception.
3. Attributes that take a list of strings (creator, software, contributor) now handle single strings as well.